### PR TITLE
fix: remove extra spaces in robots.txt

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -7,7 +7,7 @@ export const GET: APIRoute = () => {
 'Allow: /',
 '',
 'Sitemap: https://axiscabs.com/sitemap.xml',
-    ''
+''
 ].join('\n');
 
 return new Response(body, {


### PR DESCRIPTION
## Summary
- ensure robots.txt array uses a clean empty string to avoid trailing spaces

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a969b596648332969a8b1f2eb39d6a