### PR TITLE
fix cache expiry comparison

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -12,7 +12,7 @@ const store = new Map<string, Entry<any>>();
 export function cacheGet<T = unknown>(key: string): T | undefined {
 const hit = store.get(key);
 if (!hit) return undefined;
-  if (Date.now() > hit.exp) {
+  if (Date.now() >= hit.exp) {
     store.delete(key);
     return undefined;
   }


### PR DESCRIPTION
## Summary
- ensure cache entries expire at configured time by using a non-strict comparison

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a96a922c2c8332a40dbd2e2fb79187