### PR TITLE
docs: clarify environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
 # Axis Cabs MVP
 
 ## Quick Start
-1. `cp .env.example .env` and fill `PUBLIC_GA4_ID`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`.
+1. Create a `.env` file in the project root with the required environment variables:
+
+   ```
+   PUBLIC_GA4_ID=             # optional, GA4 measurement ID
+   PUBLIC_SUPABASE_URL=       # Supabase project URL
+   PUBLIC_SUPABASE_ANON_KEY=  # Supabase anon key
+   SUPABASE_URL=              # optional, same as PUBLIC_SUPABASE_URL
+   SUPABASE_SERVICE_ROLE_KEY= # service role key for API routes
+   PUBLIC_WHATSAPP_NUMBER=    # optional, WhatsApp number for CTAs
+   PUBLIC_GOOGLE_REVIEW_URL=  # optional, link to Google reviews
+   N8N_LEADS_WEBHOOK_URL=     # optional, webhook for new leads
+   ADMIN_TOKEN=               # optional, token for reviews admin API
+   ```
 2. `npm i`
 3. `npm run dev`
 4. Open http://localhost:4321
@@ -22,3 +34,4 @@
 ## Notes
 - Palette: Primary #FF6A00; consistent across components.
 - WhatsApp: +919922333305 used in Header, Hero, Sticky CTAs, and form handoff.
+


### PR DESCRIPTION
## Summary
- replace outdated `.env.example` step with manual setup instructions
- document all expected environment variables for the app

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a96a9239688332ac86f4980d4d97cd