### PR TITLE
test: add rate limiter unit tests

### DIFF
--- a/src/lib/__tests__/rateLimit.test.ts
+++ b/src/lib/__tests__/rateLimit.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from "vitest";
+import { rateLimitTry } from "../rateLimit";
+
+describe("rateLimitTry", () => {
+  it("enforces a sliding window limit", () => {
+    vi.useFakeTimers();
+    const key = "test-key";
+    const limit = 2;
+    const windowMs = 1000;
+
+    vi.setSystemTime(new Date(0));
+
+    const first = rateLimitTry(key, limit, windowMs);
+    const second = rateLimitTry(key, limit, windowMs);
+    expect(first).toEqual({ ok: true, remaining: 1, retryAfterSec: 0 });
+    expect(second).toEqual({ ok: true, remaining: 0, retryAfterSec: 0 });
+
+    const blocked = rateLimitTry(key, limit, windowMs);
+    expect(blocked).toEqual({ ok: false, remaining: 0, retryAfterSec: 1 });
+
+    vi.advanceTimersByTime(windowMs + 1);
+
+    const after = rateLimitTry(key, limit, windowMs);
+    expect(after).toEqual({ ok: true, remaining: 1, retryAfterSec: 0 });
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest-based tests for rateLimitTry ensuring windowed limits and retries reset

## Testing
- `npx vitest run src/lib/__tests__/rateLimit.test.ts` *(fails: 403 Forbidden to fetch vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68a96a9412d483328d39185620d94f6e