### PR TITLE
Add packages listing and detail pages with navigation

### DIFF
--- a/src/components/DestinationsGrid.astro
+++ b/src/components/DestinationsGrid.astro
@@ -17,12 +17,14 @@ interface Props {
   items?: DestinationItem[];
   mobileCarousel?: boolean;
   heading?: string;
+  showHeader?: boolean;
 }
 
 const {
   items = defaultItems,
   mobileCarousel = true,
-  heading = "Destinations & Experiences"
+  heading = "Destinations & Experiences",
+  showHeader = true
 } = Astro.props;
 
 const WA = (import.meta.env.PUBLIC_WHATSAPP_NUMBER || "+919922333305").replace(/\D/g, "");
@@ -118,12 +120,14 @@ const jsonLd2 = JSON.stringify(jsonLdAggregate);
 
 <section aria-labelledby="destinations-heading" class="py-12 sm:py-16 bg-white">
   <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-    <header class="mb-6 sm:mb-10 text-center">
-      <h2 id="destinations-heading" class="text-2xl sm:text-3xl font-semibold tracking-tight text-gray-900">
-        {heading}
-      </h2>
-      <p class="mt-2 text-gray-600">Curated trips with cab, stay &amp; tickets—just book and go.</p>
-    </header>
+    {showHeader && (
+      <header class="mb-6 sm:mb-10 text-center">
+        <h2 id="destinations-heading" class="text-2xl sm:text-3xl font-semibold tracking-tight text-gray-900">
+          {heading}
+        </h2>
+        <p class="mt-2 text-gray-600">Curated trips with cab, stay &amp; tickets—just book and go.</p>
+      </header>
+    )}
 
     <!-- Mobile carousel wrapper (optional) -->
     <div class:list={[
@@ -141,6 +145,8 @@ const jsonLd2 = JSON.stringify(jsonLdAggregate);
           ]}
           tabindex="-1"
           aria-label={item.title}
+          data-title={item.title.toLowerCase()}
+          data-tags={(item.tags || []).map(t => t.toLowerCase()).join(',')}
         >
           <a href={item.slug} class="block rounded-t-2xl overflow-hidden">
             <img

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,7 +11,7 @@ const waHref = `https://wa.me/${WA}?text=${DEFAULT_TEXT}`;
 const nav = [
   { href: '/', label: 'Home' },
   { href: '/city-to-city/pune-to-mumbai-cab', label: 'Routes' },
-  { href: '/packages/ajanta-ellora-2-day-itinerary', label: 'Packages' },
+  { href: '/packages', label: 'Packages' },
   { href: '/hidden-gems/ellora-secret-viewpoints', label: 'Hidden Gems' },
 ];
 ---

--- a/src/data/destinations.ts
+++ b/src/data/destinations.ts
@@ -1,59 +1,84 @@
 export type DestinationItem = {
-title: string;
-slug: string; // internal link target e.g. /packages/ajanta-ellora-2-day-itinerary
-duration: string; // "2 Days / 1 Night"
-priceFromINR: number; // starting price
-image: { src: string; alt: string };
-highlights: string[]; // ["Cab", "Hotel", "Tickets"]
+  title: string;
+  slug: string; // internal link target e.g. /packages/ajanta-ellora-2-day-itinerary
+  duration: string; // "2 Days / 1 Night"
+  priceFromINR: number; // starting price
+  image: { src: string; alt: string };
+  highlights: string[]; // ["Cab", "Hotel", "Tickets"]
+  tags?: string[];
 };
 
 export const destinations: DestinationItem[] = [
-{
-title: "Ajanta & Ellora",
-slug: "/packages/ajanta-ellora-2-day-itinerary",
-duration: "2 Days / 1 Night",
-priceFromINR: 8999,
-image: { src: "/images/destinations/ajanta-ellora.jpg", alt: "Ajanta and Ellora caves scenic view" },
-highlights: ["Cab", "Hotel", "Tickets"]
-},
-{
-title: "Shirdi Darshan",
-slug: "/packages/shirdi-darshan-weekend",
-duration: "1 Day / Same Day Return",
-priceFromINR: 4999,
-image: { src: "/images/destinations/shirdi.jpg", alt: "Shirdi temple entrance" },
-highlights: ["Cab", "Darshan Assist", "Tickets"]
-},
-{
-title: "Mumbai ↔ Pune",
-slug: "/city-to-city/pune-to-mumbai-cab",
-duration: "One‑Way / Round Trip",
-priceFromINR: 2999,
-image: { src: "/images/destinations/mumbai-pune.jpg", alt: "Mumbai–Pune Expressway valley" },
-highlights: ["Cab", "Expressway", "Tolls Optional"]
-},
-{
-title: "Goa Coastal",
-slug: "/packages/goa-3n4d-beach-escape",
-duration: "4 Days / 3 Nights",
-priceFromINR: 17999,
-image: { src: "/images/destinations/goa.jpg", alt: "Goa beach coastline at sunset" },
-highlights: ["Cab", "Hotel", "Sightseeing"]
-},
-{
-title: "Mahabaleshwar",
-slug: "/packages/mahabaleshwar-2d1n",
-duration: "2 Days / 1 Night",
-priceFromINR: 7499,
-image: { src: "/images/destinations/mahabaleshwar.jpg", alt: "Mahabaleshwar viewpoints and valleys" },
-highlights: ["Cab", "Hotel", "Mapro Visit"]
-},
-{
-title: "Golden Triangle",
-slug: "/packages/golden-triangle-5d",
-duration: "5 Days / 4 Nights",
-priceFromINR: 28999,
-image: { src: "/images/destinations/golden-triangle.jpg", alt: "Taj Mahal and India Gate collage" },
-highlights: ["Cab", "Hotel", "Tickets"]
-}
+  {
+    title: "Ajanta & Ellora",
+    slug: "/packages/ajanta-ellora-2-day-itinerary",
+    duration: "2 Days / 1 Night",
+    priceFromINR: 8999,
+    image: {
+      src: "/images/destinations/ajanta-ellora.jpg",
+      alt: "Ajanta and Ellora caves scenic view",
+    },
+    highlights: ["Cab", "Hotel", "Tickets"],
+    tags: ["Weekend", "Heritage"],
+  },
+  {
+    title: "Shirdi Darshan",
+    slug: "/packages/shirdi-darshan-weekend",
+    duration: "1 Day / Same Day Return",
+    priceFromINR: 4999,
+    image: {
+      src: "/images/destinations/shirdi.jpg",
+      alt: "Shirdi temple entrance",
+    },
+    highlights: ["Cab", "Darshan Assist", "Tickets"],
+    tags: ["Pilgrimage", "Weekend"],
+  },
+  {
+    title: "Mumbai ↔ Pune",
+    slug: "/city-to-city/pune-to-mumbai-cab",
+    duration: "One‑Way / Round Trip",
+    priceFromINR: 2999,
+    image: {
+      src: "/images/destinations/mumbai-pune.jpg",
+      alt: "Mumbai–Pune Expressway valley",
+    },
+    highlights: ["Cab", "Expressway", "Tolls Optional"],
+    tags: ["City", "Transfer"],
+  },
+  {
+    title: "Goa Coastal",
+    slug: "/packages/goa-3n4d-beach-escape",
+    duration: "4 Days / 3 Nights",
+    priceFromINR: 17999,
+    image: {
+      src: "/images/destinations/goa.jpg",
+      alt: "Goa beach coastline at sunset",
+    },
+    highlights: ["Cab", "Hotel", "Sightseeing"],
+    tags: ["Beach", "Leisure"],
+  },
+  {
+    title: "Mahabaleshwar",
+    slug: "/packages/mahabaleshwar-2d1n",
+    duration: "2 Days / 1 Night",
+    priceFromINR: 7499,
+    image: {
+      src: "/images/destinations/mahabaleshwar.jpg",
+      alt: "Mahabaleshwar viewpoints and valleys",
+    },
+    highlights: ["Cab", "Hotel", "Mapro Visit"],
+    tags: ["Weekend", "Hill"],
+  },
+  {
+    title: "Golden Triangle",
+    slug: "/packages/golden-triangle-5d",
+    duration: "5 Days / 4 Nights",
+    priceFromINR: 28999,
+    image: {
+      src: "/images/destinations/golden-triangle.jpg",
+      alt: "Taj Mahal and India Gate collage",
+    },
+    highlights: ["Cab", "Hotel", "Tickets"],
+    tags: ["Heritage", "Culture"],
+  },
 ];

--- a/src/data/packages.ts
+++ b/src/data/packages.ts
@@ -8,18 +8,91 @@ export type PackageEntry = {
 
 export const packages: PackageEntry[] = [
   {
-    slug: 'ajanta-ellora-2-day-itinerary',
-    title: 'Ajanta & Ellora 2‑Day Itinerary — Caves, Fort & Local Food',
-    summary: 'Private cab • Handpicked stops • Flexible timing',
+    slug: "ajanta-ellora-2-day-itinerary",
+    title: "Ajanta & Ellora 2‑Day Itinerary — Caves, Fort & Local Food",
+    summary: "Private cab • Handpicked stops • Flexible timing",
     days: [
-      { day: 'Day 1', items: ['Ellora Caves', 'Grishneshwar Temple', 'Daulatabad Fort (optional)'] },
-      { day: 'Day 2', items: ['Ajanta Caves', 'Scenic viewpoints', 'Local thali stop'] }
+      {
+        day: "Day 1",
+        items: [
+          "Ellora Caves",
+          "Grishneshwar Temple",
+          "Daulatabad Fort (optional)",
+        ],
+      },
+      {
+        day: "Day 2",
+        items: ["Ajanta Caves", "Scenic viewpoints", "Local thali stop"],
+      },
     ],
     faqs: [
-      { q: 'Best season?', a: 'Oct–Mar is ideal; summers are hot.' },
-      { q: 'Entry tickets included?', a: 'Tickets & meals excluded; included in your final quote on request.' }
-    ]
+      { q: "Best season?", a: "Oct–Mar is ideal; summers are hot." },
+      {
+        q: "Entry tickets included?",
+        a: "Tickets & meals excluded; included in your final quote on request.",
+      },
+    ],
   },
-  { slug: 'goa-3-day-relax-itinerary', title: 'Goa 3‑Day Relax Itinerary — Beach & Forts', summary: 'North & South split • Sunset points • Optional watersports', days: [], faqs: [] },
-  { slug: 'varanasi-2-day-rituals-heritage', title: 'Varanasi 2‑Day — Rituals & Heritage', summary: 'Ghat walks • Evening aarti • Silk alley', days: [], faqs: [] }
+  {
+    slug: "shirdi-darshan-weekend",
+    title: "Shirdi Darshan Weekend — Sai Baba Temple & Local Stops",
+    summary: "Private cab • Darshan assistance • Same day return",
+    days: [
+      {
+        day: "Day 1",
+        items: [
+          "Early morning pickup",
+          "Shirdi Sai Baba Temple",
+          "Local sightseeing",
+          "Return by night",
+        ],
+      },
+    ],
+    faqs: [],
+  },
+  {
+    slug: "goa-3n4d-beach-escape",
+    title: "Goa 4‑Day Beach Escape — Sun, Sand & Forts",
+    summary:
+      "Airport transfers • North & South Goa tours • Optional watersports",
+    days: [
+      {
+        day: "Day 1",
+        items: ["Arrive Goa", "Check‑in", "Evening on the beach"],
+      },
+      { day: "Day 2", items: ["North Goa tour: Fort Aguada, Calangute, Baga"] },
+      {
+        day: "Day 3",
+        items: ["South Goa tour: Colva Beach, Basilica of Bom Jesus"],
+      },
+      { day: "Day 4", items: ["Checkout and departure"] },
+    ],
+    faqs: [],
+  },
+  {
+    slug: "mahabaleshwar-2d1n",
+    title: "Mahabaleshwar 2‑Day Getaway — Hills & Strawberries",
+    summary: "Scenic viewpoints • Mapro Garden • Flexible schedule",
+    days: [
+      {
+        day: "Day 1",
+        items: ["Pickup from Pune", "Mapro Garden", "Arthur Seat Point"],
+      },
+      { day: "Day 2", items: ["Pratapgad Fort", "Return to Pune"] },
+    ],
+    faqs: [],
+  },
+  {
+    slug: "golden-triangle-5d",
+    title: "Golden Triangle 5‑Day Tour — Delhi, Agra & Jaipur",
+    summary: "Private cab • Guided sightseeing • Customisable plan",
+    days: [
+      { day: "Day 1", items: ["Arrive Delhi", "City tour"] },
+      { day: "Day 2", items: ["Delhi to Agra", "Taj Mahal visit"] },
+      { day: "Day 3", items: ["Agra to Jaipur", "Fatehpur Sikri en route"] },
+      { day: "Day 4", items: ["Jaipur city tour: Amber Fort, Hawa Mahal"] },
+      { day: "Day 5", items: ["Return to Delhi"] },
+    ],
+    faqs: [],
+  },
 ];

--- a/src/pages/packages/[slug].astro
+++ b/src/pages/packages/[slug].astro
@@ -2,10 +2,10 @@
 import '../../styles/globals.css';
 import Header from '@/components/Header.astro';
 import Footer from '@/components/Footer.astro';
-import Hero from '@/components/Hero.astro';
 import LeadForm from '@/components/LeadForm.astro';
 import FAQ from '@/components/FAQ.astro';
 import { packages } from '@/data/packages';
+import { destinations } from '@/data/destinations';
 import pricing from '@/data/pricing.json';
 import Analytics from '@/components/Analytics.astro';
 
@@ -18,6 +18,17 @@ const entry = packages.find((p) => p.slug === slug);
 if (!entry) return Astro.redirect('/');
 
 const band = pricing.packages?.[slug!];
+const dest = destinations.find(d => d.slug.replace(/^\/packages\//, '') === slug);
+const WA = (import.meta.env.PUBLIC_WHATSAPP_NUMBER || '+919922333305').replace(/\D/g, '');
+const waText = encodeURIComponent(`Hi Axis Cabs 👋\nI'm interested in "${entry.title}". Please share details.`);
+const waHref = `https://wa.me/${WA}?text=${waText}`;
+function formatINR(n: number) {
+  try {
+    return new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR', maximumFractionDigits: 0 }).format(n);
+  } catch {
+    return `₹${n.toLocaleString('en-IN')}`;
+  }
+}
 ---
 <html lang="en">
   <head>
@@ -30,7 +41,30 @@ const band = pricing.packages?.[slug!];
   </head>
   <body>
     <Header />
-    <Hero title={entry.title} sub={entry.summary} />
+    {dest && (
+      <section>
+        <img src={dest.image.src} alt={dest.image.alt} class="w-full h-64 md:h-96 object-cover" />
+      </section>
+    )}
+    <section class="max-w-6xl mx-auto px-4 py-6">
+      <h1 class="text-3xl font-bold">{entry.title}</h1>
+      <p class="mt-2 text-lg opacity-80">{entry.summary}</p>
+      {dest && (
+        <div class="mt-4 flex flex-wrap gap-2">
+          {dest.highlights.map(h => <span class="text-xs font-medium px-2.5 py-1 rounded-full bg-gray-100">{h}</span>)}
+        </div>
+      )}
+      {dest && (
+        <div class="mt-4 flex flex-wrap items-center gap-4">
+          <span class="text-2xl font-bold">{formatINR(dest.priceFromINR)}</span>
+          <span class="opacity-70">{dest.duration}</span>
+        </div>
+      )}
+      <div class="mt-4 flex gap-3">
+        <a href={waHref} class="inline-flex items-center px-5 py-3 rounded-xl border border-primary font-semibold">Chat on WhatsApp</a>
+        <a href="#lead-form" class="btn-primary">Book / Get Quote</a>
+      </div>
+    </section>
     <main class="mx-auto max-w-6xl px-4 grid md:grid-cols-3 gap-8">
       <div class="md:col-span-2">
         <section class="card">
@@ -58,6 +92,12 @@ const band = pricing.packages?.[slug!];
           <h3 class="text-lg font-bold mb-3">Get Your Quote</h3>
           <LeadForm />
         </section>
+        {entry.faqs.length > 0 && (
+          <section class="mt-6">
+            <h3 class="text-lg font-bold mb-3">FAQ</h3>
+            <FAQ items={entry.faqs} />
+          </section>
+        )}
       </div>
       <aside class="space-y-4">
         <div class="card"><strong>Why Axis Cabs?</strong><p class="text-sm mt-2 opacity-80">Local expertise • Flexible timing • Premium support</p></div>

--- a/src/pages/packages/index.astro
+++ b/src/pages/packages/index.astro
@@ -1,0 +1,68 @@
+---
+import '../../styles/globals.css';
+import Header from '@/components/Header.astro';
+import Footer from '@/components/Footer.astro';
+import DestinationsGrid from '@/components/DestinationsGrid.astro';
+import { destinations } from '@/data/destinations';
+
+const allPackages = destinations.filter(d => d.slug.startsWith('/packages/'));
+const tags = Array.from(new Set(allPackages.flatMap(p => p.tags || []))).sort();
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Packages | Axis Cabs</title>
+    <meta name="description" content="Browse all tour packages offered by Axis Cabs" />
+    <link rel="icon" href="/favicon.svg" />
+  </head>
+  <body>
+    <Header />
+    <main class="py-10">
+      <div class="max-w-6xl mx-auto px-4">
+        <h1 class="text-3xl font-bold mb-4">Packages</h1>
+        <div class="flex flex-col sm:flex-row sm:items-center gap-4 mb-6">
+          <input id="pkg-search" type="search" placeholder="Where do you want to go?" class="border rounded-xl px-4 py-2 w-full sm:w-72" />
+          <div id="pkg-tags" class="flex flex-wrap gap-2">
+            {tags.map(t => (
+              <button type="button" class="px-3 py-1 rounded-full border text-sm" data-filter-tag={t.toLowerCase()}>{t}</button>
+            ))}
+          </div>
+        </div>
+        <div id="packages-grid">
+          <DestinationsGrid items={allPackages} mobileCarousel={false} showHeader={false} />
+        </div>
+      </div>
+    </main>
+    <Footer />
+    <script>
+      const search = document.getElementById('pkg-search');
+      const cards = Array.from(document.querySelectorAll('#packages-grid article'));
+      const buttons = Array.from(document.querySelectorAll('[data-filter-tag]'));
+      function applyFilters() {
+        const q = (search.value || '').toLowerCase();
+        const activeBtn = document.querySelector('[data-filter-tag].active');
+        const active = activeBtn ? activeBtn.dataset.filterTag : null;
+        cards.forEach(card => {
+          const title = (card.dataset.title || '').toLowerCase();
+          const tags = (card.dataset.tags || '').split(',');
+          const matchesQ = title.includes(q);
+          const matchesTag = !active || tags.includes(active);
+          card.classList.toggle('hidden', !(matchesQ && matchesTag));
+        });
+      }
+      search.addEventListener('input', applyFilters);
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          if (btn.classList.contains('active')) {
+            btn.classList.remove('active','bg-orange-600','text-white');
+          } else {
+            buttons.forEach(b => b.classList.remove('active','bg-orange-600','text-white'));
+            btn.classList.add('active','bg-orange-600','text-white');
+          }
+          applyFilters();
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- expand packages data and destination tags
- add packages index page with search and tag filters
- enhance package detail page with hero image, pricing and FAQs
- update navigation to point to packages overview

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a97150167c8332aa21be4146f503de