### PR TITLE
Handle invalid JSON in lead submission API

### DIFF
--- a/src/pages/api/leads-submit.ts
+++ b/src/pages/api/leads-submit.ts
@@ -70,7 +70,12 @@ export const POST: APIRoute = async ({ request }) => {
     return json(400, { ok: false, error: 'Use application/json' });
   }
 
-  const body = (await request.json()) as Record<string, any>;
+  let body: Record<string, any>;
+  try {
+    body = (await request.json()) as Record<string, any>;
+  } catch {
+    return json(400, { ok: false, error: 'Invalid JSON' });
+  }
 
   // honeypot: "company" (if filled, accept silently)
   if (typeof body.company === 'string' && body.company.trim() !== '') {


### PR DESCRIPTION
## Summary
- guard against invalid JSON in lead submission endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx prettier --check src/pages/api/leads-submit.ts` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68a989abfb4483329460e721540e348b