### PR TITLE
Use placeholder image for destinations

### DIFF
--- a/src/data/destinations.ts
+++ b/src/data/destinations.ts
@@ -8,16 +8,15 @@ export type DestinationItem = {
   tags?: string[];
 };
 
+const placeholderImage = { src: "/logo.png", alt: "Axis Cabs logo" };
+
 export const destinations: DestinationItem[] = [
   {
     title: "Ajanta & Ellora",
     slug: "/packages/ajanta-ellora-2-day-itinerary",
     duration: "2 Days / 1 Night",
     priceFromINR: 8999,
-    image: {
-      src: "/images/destinations/ajanta-ellora.jpg",
-      alt: "Ajanta and Ellora caves scenic view",
-    },
+    image: placeholderImage,
     highlights: ["Cab", "Hotel", "Tickets"],
     tags: ["Weekend", "Heritage"],
   },
@@ -26,10 +25,7 @@ export const destinations: DestinationItem[] = [
     slug: "/packages/shirdi-darshan-weekend",
     duration: "1 Day / Same Day Return",
     priceFromINR: 4999,
-    image: {
-      src: "/images/destinations/shirdi.jpg",
-      alt: "Shirdi temple entrance",
-    },
+    image: placeholderImage,
     highlights: ["Cab", "Darshan Assist", "Tickets"],
     tags: ["Pilgrimage", "Weekend"],
   },
@@ -38,10 +34,7 @@ export const destinations: DestinationItem[] = [
     slug: "/city-to-city/pune-to-mumbai-cab",
     duration: "One‑Way / Round Trip",
     priceFromINR: 2999,
-    image: {
-      src: "/images/destinations/mumbai-pune.jpg",
-      alt: "Mumbai–Pune Expressway valley",
-    },
+    image: placeholderImage,
     highlights: ["Cab", "Expressway", "Tolls Optional"],
     tags: ["City", "Transfer"],
   },
@@ -50,10 +43,7 @@ export const destinations: DestinationItem[] = [
     slug: "/packages/goa-3n4d-beach-escape",
     duration: "4 Days / 3 Nights",
     priceFromINR: 17999,
-    image: {
-      src: "/images/destinations/goa.jpg",
-      alt: "Goa beach coastline at sunset",
-    },
+    image: placeholderImage,
     highlights: ["Cab", "Hotel", "Sightseeing"],
     tags: ["Beach", "Leisure"],
   },
@@ -62,10 +52,7 @@ export const destinations: DestinationItem[] = [
     slug: "/packages/mahabaleshwar-2d1n",
     duration: "2 Days / 1 Night",
     priceFromINR: 7499,
-    image: {
-      src: "/images/destinations/mahabaleshwar.jpg",
-      alt: "Mahabaleshwar viewpoints and valleys",
-    },
+    image: placeholderImage,
     highlights: ["Cab", "Hotel", "Mapro Visit"],
     tags: ["Weekend", "Hill"],
   },
@@ -74,10 +61,7 @@ export const destinations: DestinationItem[] = [
     slug: "/packages/golden-triangle-5d",
     duration: "5 Days / 4 Nights",
     priceFromINR: 28999,
-    image: {
-      src: "/images/destinations/golden-triangle.jpg",
-      alt: "Taj Mahal and India Gate collage",
-    },
+    image: placeholderImage,
     highlights: ["Cab", "Hotel", "Tickets"],
     tags: ["Heritage", "Culture"],
   },


### PR DESCRIPTION
## Summary
- show a single placeholder image for all destinations using `/logo.png`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a98cf9477c8332abfa77052b4811bc