### PR TITLE
feat: capture vehicle type on leads

### DIFF
--- a/src/components/LeadForm.astro
+++ b/src/components/LeadForm.astro
@@ -16,6 +16,13 @@ const WA_NUM = (import.meta.env.PUBLIC_WHATSAPP_NUMBER || '+919922333305').repla
     <input required name="date" type="date" class="border rounded-xl px-4 py-3" />
     <input required name="time" type="time" step="900" class="border rounded-xl px-4 py-3" />
 
+    <select required name="vehicle" class="border rounded-xl px-4 py-3">
+      <option value="sedan">Sedan</option>
+      <option value="suv">SUV</option>
+      <option value="luxury">Luxury</option>
+      <option value="traveller">Traveller</option>
+    </select>
+
     <input required name="pax"  inputmode="numeric" type="text" minlength="1" maxlength="2"
            placeholder="Passengers" class="border rounded-xl px-4 py-3" />
     <input name="bags" inputmode="numeric" type="text" minlength="1" maxlength="2"
@@ -66,6 +73,7 @@ const WA_NUM = (import.meta.env.PUBLIC_WHATSAPP_NUMBER || '+919922333305').repla
         to: q('to_city'),
         date: q('date'),
         time: q('time'),
+        vehicle: q('vehicle'),
         pax: q('pax'),
         bags: q('bags'),
         name: q('name'),
@@ -151,7 +159,7 @@ const WA_NUM = (import.meta.env.PUBLIC_WHATSAPP_NUMBER || '+919922333305').repla
       function validateFields() {
         const fd = new FormData(form);
         const get = (k) => String(fd.get(k) || '').trim();
-        const req = ['from_city','to_city','date','time','pax','name','whatsapp'];
+        const req = ['from_city','to_city','date','time','vehicle','pax','name','whatsapp'];
         for (const k of req) if (!get(k)) return `Please fill “${k.replace('_',' ')}”.`;
         if (!/^[0-9]{10}$/.test(get('whatsapp'))) return 'Enter a valid 10-digit WhatsApp number.';
         const pax = parseInt(get('pax'), 10); if (!(pax >= 1 && pax <= 12)) return 'Passengers must be between 1 and 12.';
@@ -200,6 +208,7 @@ const WA_NUM = (import.meta.env.PUBLIC_WHATSAPP_NUMBER || '+919922333305').repla
         if (!q) return;
         if (fields.from) fields.from.value = (q.from || '').toString();
         if (fields.to)   fields.to.value   = (q.to || '').toString();
+        if (fields.vehicle && q.vehicle) fields.vehicle.value = (q.vehicle || '').toString();
         if (fields.notes) {
           const noteLine = buildQuoteNote(q);
           const current = (fields.notes.value || '').trim();
@@ -236,6 +245,7 @@ const WA_NUM = (import.meta.env.PUBLIC_WHATSAPP_NUMBER || '+919922333305').repla
           const t =
             `Ride request:%0AFrom: ${encodeURIComponent(fields.from.value)}` +
             `%0ATo: ${encodeURIComponent(fields.to.value)}` +
+            `%0AVehicle: ${encodeURIComponent(fields.vehicle.value)}` +
             `%0ADate/Time: ${encodeURIComponent(fields.date.value)} ${encodeURIComponent(fields.time.value)}` +
             `%0APax/Bags: ${encodeURIComponent(fields.pax.value)}/${encodeURIComponent(fields.bags.value || '0')}` +
             `%0ANotes: ${encodeURIComponent(fields.notes.value || '')}`;

--- a/src/pages/admin/leads.astro
+++ b/src/pages/admin/leads.astro
@@ -89,6 +89,7 @@
               <th class="px-2 py-1">Name</th>
               <th class="px-2 py-1">Phone</th>
               <th class="px-2 py-1">Route</th>
+              <th class="px-2 py-1">Vehicle</th>
               <th class="px-2 py-1">When</th>
               <th class="px-2 py-1">Status</th>
             </tr>
@@ -98,11 +99,13 @@
         data.items.forEach((item) => {
           const tr = document.createElement('tr');
           const route = [item.from_city, item.to_city].filter(Boolean).join(' → ');
+          const vehicle = item.vehicle || '';
           const when = [item.date, item.time].filter(Boolean).join(' ');
           tr.innerHTML = `
             <td class="border-t px-2 py-1">${item.name || ''}</td>
             <td class="border-t px-2 py-1">${item.whatsapp || ''}</td>
             <td class="border-t px-2 py-1">${route}</td>
+            <td class="border-t px-2 py-1">${vehicle}</td>
             <td class="border-t px-2 py-1">${when}</td>
             <td class="border-t px-2 py-1">
               <select data-id="${item.id}" class="status-select rounded border border-slate-300 px-2 py-1">

--- a/src/pages/api/leads-admin.ts
+++ b/src/pages/api/leads-admin.ts
@@ -29,7 +29,7 @@ export const GET: APIRoute = async ({ request }) => {
   let { data, error, count } = await supabase
     .from("leads")
     .select(
-      "id,created_at,name,whatsapp,from_city,to_city,date,time,status,notes",
+      "id,created_at,name,whatsapp,from_city,to_city,date,time,vehicle,status,notes",
       { count: "exact" },
     )
     .eq("status", status)

--- a/src/pages/api/leads-submit.ts
+++ b/src/pages/api/leads-submit.ts
@@ -1,31 +1,28 @@
-import type { APIRoute } from 'astro';
-import { createClient } from '@supabase/supabase-js';
+import type { APIRoute } from "astro";
+import { createClient } from "@supabase/supabase-js";
 
 export const prerender = false;
 
 // Prefer runtime env (Netlify), fallback to Vite env (dev)
-const SUPABASE_URL =
-(process.env.SUPABASE_URL ||
-process.env.PUBLIC_SUPABASE_URL ||
-import.meta.env.SUPABASE_URL ||
-import.meta.env.PUBLIC_SUPABASE_URL) as string;
+const SUPABASE_URL = (process.env.SUPABASE_URL ||
+  process.env.PUBLIC_SUPABASE_URL ||
+  import.meta.env.SUPABASE_URL ||
+  import.meta.env.PUBLIC_SUPABASE_URL) as string;
 
-const SERVICE_KEY =
-(process.env.SUPABASE_SERVICE_ROLE_KEY ||
-import.meta.env.SUPABASE_SERVICE_ROLE_KEY) as string;
+const SERVICE_KEY = (process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  import.meta.env.SUPABASE_SERVICE_ROLE_KEY) as string;
 
-const WEBHOOK =
-(process.env.N8N_LEADS_WEBHOOK_URL ||
-import.meta.env.N8N_LEADS_WEBHOOK_URL ||
-'') as string;
+const WEBHOOK = (process.env.N8N_LEADS_WEBHOOK_URL ||
+  import.meta.env.N8N_LEADS_WEBHOOK_URL ||
+  "") as string;
 
-const digits = (s: any) => String(s ?? '').replace(/\D/g, '');
-const emptyToNull = (v: any) => (v === '' ? null : v);
+const digits = (s: any) => String(s ?? "").replace(/\D/g, "");
+const emptyToNull = (v: any) => (v === "" ? null : v);
 
 function json(status: number, body: unknown) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'content-type': 'application/json' },
+    headers: { "content-type": "application/json" },
   });
 }
 
@@ -35,13 +32,15 @@ async function postWebhook(url: string, payload: Record<string, any>) {
   const t = setTimeout(() => ctrl.abort(), 3000);
   try {
     const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
       signal: ctrl.signal,
     });
     let b: any = null;
-    try { b = await res.json(); } catch {}
+    try {
+      b = await res.json();
+    } catch {}
     return { ok: res.ok, status: res.status, body: b };
   } catch {
     return { ok: false, status: 0 };
@@ -52,62 +51,65 @@ async function postWebhook(url: string, payload: Record<string, any>) {
 
 // Debug/ping helpers
 export const GET: APIRoute = async ({ url }) => {
-  if (url.searchParams.get('debug') === '1') {
+  if (url.searchParams.get("debug") === "1") {
     return json(200, { ok: true, hasWebhook: !!WEBHOOK });
   }
-  if (url.searchParams.get('ping') === '1') {
+  if (url.searchParams.get("ping") === "1") {
     const res = await postWebhook(WEBHOOK, { ping: true, ts: Date.now() });
     return json(200, { ok: res.ok, status: res.status });
   }
-  return json(200, { ok: true, msg: 'POST a lead to this endpoint.' });
+  return json(200, { ok: true, msg: "POST a lead to this endpoint." });
 };
 
 export const POST: APIRoute = async ({ request }) => {
   if (!SUPABASE_URL || !SERVICE_KEY) {
-    return json(500, { ok: false, error: 'Server env missing' });
+    return json(500, { ok: false, error: "Server env missing" });
   }
-  if (!(request.headers.get('content-type') || '').includes('application/json')) {
-    return json(400, { ok: false, error: 'Use application/json' });
+  if (
+    !(request.headers.get("content-type") || "").includes("application/json")
+  ) {
+    return json(400, { ok: false, error: "Use application/json" });
   }
 
   let body: Record<string, any>;
   try {
     body = (await request.json()) as Record<string, any>;
   } catch {
-    return json(400, { ok: false, error: 'Invalid JSON' });
+    return json(400, { ok: false, error: "Invalid JSON" });
   }
 
   // honeypot: "company" (if filled, accept silently)
-  if (typeof body.company === 'string' && body.company.trim() !== '') {
+  if (typeof body.company === "string" && body.company.trim() !== "") {
     return json(200, { ok: true, queued: true });
   }
 
-  const name = String(body.name || '').trim();
-  const whatsapp = digits(body.whatsapp || body.phone || '');
+  const name = String(body.name || "").trim();
+  const whatsapp = digits(body.whatsapp || body.phone || "");
   if (!name || whatsapp.length < 8) {
-    return json(400, { ok: false, error: 'Name and valid phone required' });
+    return json(400, { ok: false, error: "Name and valid phone required" });
   }
 
   const row: Record<string, any> = {
-    source: 'web',
-    status: 'new',
+    source: "web",
+    status: "new",
     name,
     whatsapp,
-    from_city: emptyToNull(body.from_city || body.from || ''),
-    to_city: emptyToNull(body.to_city || body.to || ''),
-    date: emptyToNull(body.date || ''),
-    time: emptyToNull(body.time || ''),
-    pax: emptyToNull(digits(body.pax || '')),
-    bags: emptyToNull(digits(body.bags || '')),
-    notes: emptyToNull(body.notes || ''),
-    page: emptyToNull(body.page_path || body.page || ''),
-    referrer: emptyToNull(body.referrer || ''),
-    utm_source: body.utm_source || '',
-    utm_medium: body.utm_medium || '',
-    utm_campaign: body.utm_campaign || '',
-    utm_term: body.utm_term || '',
-    utm_content: body.utm_content || '',
-    gclid: body.gclid || '',
+    from_city: emptyToNull(body.from_city || body.from || ""),
+    to_city: emptyToNull(body.to_city || body.to || ""),
+    date: emptyToNull(body.date || ""),
+    time: emptyToNull(body.time || ""),
+    vehicle: emptyToNull(body.vehicle || ""),
+    pax: emptyToNull(digits(body.pax || "")),
+    bags: emptyToNull(digits(body.bags || "")),
+    notes: emptyToNull(body.notes || ""),
+    page: emptyToNull(body.page_path || body.page || ""),
+    referrer: emptyToNull(body.referrer || ""),
+    utm_source: body.utm_source || "",
+    utm_medium: body.utm_medium || "",
+    utm_campaign: body.utm_campaign || "",
+    utm_term: body.utm_term || "",
+    utm_content: body.utm_content || "",
+    gclid: body.gclid || "",
   };
 
   const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
@@ -116,9 +118,9 @@ export const POST: APIRoute = async ({ request }) => {
   let payload = { ...row };
   for (let i = 0; i < 10; i++) {
     const { data, error } = await supabase
-      .from('leads')
+      .from("leads")
       .insert(payload)
-      .select('id')
+      .select("id")
       .single();
 
     if (!error) {
@@ -126,17 +128,23 @@ export const POST: APIRoute = async ({ request }) => {
       return json(200, { ok: true, id: data!.id });
     }
 
-    const msg = String(error.message || '');
+    const msg = String(error.message || "");
     const m1 = msg.match(/Could not find the '([^']+)' column/i);
-    const m2 = msg.match(/column "([^"]+)" of relation "leads" does not exist/i);
+    const m2 = msg.match(
+      /column "([^"]+)" of relation "leads" does not exist/i,
+    );
     const unknown = (m1 && m1[1]) || (m2 && m2[1]) || null;
 
-    if (unknown && unknown in payload && !['name', 'whatsapp'].includes(unknown)) {
+    if (
+      unknown &&
+      unknown in payload &&
+      !["name", "whatsapp"].includes(unknown)
+    ) {
       delete payload[unknown];
       continue;
     }
     return json(500, { ok: false, error: msg });
   }
 
-  return json(500, { ok: false, error: 'Insert failed' });
+  return json(500, { ok: false, error: "Insert failed" });
 };

--- a/supabase/202407080000_add_vehicle_to_leads.sql
+++ b/supabase/202407080000_add_vehicle_to_leads.sql
@@ -1,0 +1,2 @@
+-- Add vehicle column to leads table
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS vehicle text;


### PR DESCRIPTION
## Summary
- add vehicle dropdown to lead form and include in WhatsApp link
- store vehicle type in leads API and expose in admin endpoints
- show vehicle column in admin UI and add SQL migration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9dc58eb808332a0ee6f6dda9cea8d