### PR TITLE
fix: prevent reviews aggregate from failing when empty

### DIFF
--- a/src/pages/api/reviews-list.ts
+++ b/src/pages/api/reviews-list.ts
@@ -78,7 +78,7 @@ export const GET: APIRoute = async ({ request }) => {
       .from("reviews")
       .select("avg(rating)", { count: "exact" })
       .eq("status", "approved")
-      .single();
+      .maybeSingle();
 
     if (aggErr) return json({ ok: false, error: aggErr.message }, 500);
 


### PR DESCRIPTION
## Summary
- handle empty review tables by using maybeSingle in reviews aggregate query

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a9eb101048833290ab0b9852d310dd