### PR TITLE
fix reviews aggregate count query

### DIFF
--- a/src/pages/api/reviews-list.ts
+++ b/src/pages/api/reviews-list.ts
@@ -72,7 +72,7 @@ export const GET: APIRoute = async ({ request }) => {
     // Aggregate average rating and total count without schema cache issues
     const { data: aggregate, error: aggErr } = await client
       .from("reviews")
-      .select("count:count(id), average:avg(rating)")
+      .select("count(*), average:avg(rating)")
       .eq("status", "approved")
       .single();
 
@@ -82,7 +82,6 @@ export const GET: APIRoute = async ({ request }) => {
     const average = totalCount
       ? Number(Number(aggregate.average || 0).toFixed(2))
       : 0;
-
 
     const hasMore =
       count != null


### PR DESCRIPTION
## Summary
- use a valid Supabase aggregation for review count and average rating

## Testing
- `curl -i http://localhost:4321/api/reviews-list` *(fails: Server not configured (Supabase))*


------
https://chatgpt.com/codex/tasks/task_e_68a9f085f2f08332bf7be0218a7816f1