### PR TITLE
Handle review fetch errors with notice

### DIFF
--- a/src/components/ReviewsSection.astro
+++ b/src/components/ReviewsSection.astro
@@ -174,19 +174,25 @@ const reviewsJsonLd = aggregate
   async function fetchAllReviews() {
     const pageSize = 24;
     let page = 1, all = [], more = true;
-    while (more && page <= 20) {
-      const url = new URL(`${FN_BASE}/reviews-list`, location.origin);
-      url.searchParams.set('page', String(page));
-      url.searchParams.set('pageSize', String(pageSize));
-      const res  = await fetch(url.toString(), { headers: { accept: 'application/json' } });
-      const data = await safeJson(res);
-      if (!res.ok || !data?.ok) break;
-      aggregate = data.aggregate || aggregate;
-      all  = all.concat(Array.isArray(data.items) ? data.items : []);
-      more = !!data.hasMore;
-      page += 1;
+    try {
+      while (more && page <= 20) {
+        const url = new URL(`${FN_BASE}/reviews-list`, location.origin);
+        url.searchParams.set('page', String(page));
+        url.searchParams.set('pageSize', String(pageSize));
+        const res  = await fetch(url.toString(), { headers: { accept: 'application/json' } });
+        const data = await safeJson(res);
+        if (!res.ok || !data?.ok) break;
+        aggregate = data.aggregate || aggregate;
+        all  = all.concat(Array.isArray(data.items) ? data.items : []);
+        more = !!data.hasMore;
+        page += 1;
+      }
+      return all;
+    } catch (err) {
+      console.error(err);
+      runner.innerHTML = '<p class="text-sm text-slate-500">Unable to load reviews right now.</p>';
+      return null;
     }
-    return all;
   }
 
   // --- RAF marquee ---
@@ -221,8 +227,10 @@ const reviewsJsonLd = aggregate
   (async () => {
     const items = await fetchAllReviews();
 
-    if (!items.length) {
-      runner.innerHTML = '<p class="text-sm text-slate-500">No reviews yet. Be the first to share your experience!</p>';
+    if (!items || !items.length) {
+      if (!runner.innerHTML) {
+        runner.innerHTML = '<p class="text-sm text-slate-500">No reviews yet. Be the first to share your experience!</p>';
+      }
       // Still update JSON-LD so at least baseline renders
       updateJsonLd();
       return;


### PR DESCRIPTION
## Summary
- handle errors when fetching reviews and show fallback message
- avoid overwriting error notice when no reviews are returned

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9f35ecc0c8332ba1c70df7acaa4fc