### PR TITLE
Handle missing review aggregates gracefully

### DIFF
--- a/src/pages/api/reviews-list.ts
+++ b/src/pages/api/reviews-list.ts
@@ -74,13 +74,15 @@ export const GET: APIRoute = async ({ request }) => {
       .from("reviews")
       .select("count(*), average:avg(rating)")
       .eq("status", "approved")
-      .single();
+      .maybeSingle();
 
     if (aggErr) return json({ ok: false, error: aggErr.message }, 500);
 
-    const totalCount = aggregate?.count ? Number(aggregate.count) : 0;
+    const { count: rawCount, average: rawAvg } =
+      aggregate ?? { count: 0, average: 0 };
+    const totalCount = rawCount ? Number(rawCount) : 0;
     const average = totalCount
-      ? Number(Number(aggregate.average || 0).toFixed(2))
+      ? Number(Number(rawAvg || 0).toFixed(2))
       : 0;
 
     const hasMore =


### PR DESCRIPTION
## Summary
- Use `maybeSingle` for the reviews aggregate query
- Default aggregate result to `{ count: 0, average: 0 }` when no rows are returned

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9f360b82483328a23cd307a31b1c7