### PR TITLE
feat: add story section to package detail

### DIFF
--- a/src/components/story/EditorialSplit.astro
+++ b/src/components/story/EditorialSplit.astro
@@ -1,0 +1,24 @@
+---
+interface Block {
+  title?: string;
+  body: string;
+}
+interface Props {
+  image: { src: string; alt: string };
+  blocks: Block[];
+}
+const { image, blocks } = Astro.props as Props;
+---
+<div class="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+  <div class="space-y-8">
+    {blocks.map((block, i) => (
+      <article>
+        {block.title && <h4 class="font-semibold mb-2">{block.title}</h4>}
+        <p class="text-sm opacity-80">{block.body}</p>
+      </article>
+    ))}
+  </div>
+  <div class="sticky top-24 self-start">
+    <img src={image.src} alt={image.alt} class="w-full h-full object-cover rounded-lg" />
+  </div>
+</div>

--- a/src/components/story/QuoteOverlay.astro
+++ b/src/components/story/QuoteOverlay.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  image: { src: string; alt: string };
+  quote: string;
+  attribution: string;
+}
+const { image, quote, attribution } = Astro.props as Props;
+---
+<div class="relative aspect-[16/7] overflow-hidden rounded-lg">
+  <img src={image.src} alt={image.alt} class="absolute inset-0 h-full w-full object-cover" />
+  <div class="relative z-10 h-full w-full bg-gradient-to-r from-black/60 to-transparent flex flex-col justify-end text-white p-6">
+    <svg viewBox="0 0 24 24" class="w-8 h-8 mb-4" fill="currentColor" aria-hidden="true">
+      <path d="M7 17h3V8H5v7h2Zm9-9v7h3V8h-3Z" />
+    </svg>
+    <blockquote class="text-lg md:text-xl leading-snug">{quote}</blockquote>
+    <cite class="mt-2 text-sm not-italic">{attribution}</cite>
+  </div>
+</div>

--- a/src/components/story/StoryTemplateSwitcher.astro
+++ b/src/components/story/StoryTemplateSwitcher.astro
@@ -1,0 +1,28 @@
+---
+import EditorialSplit from './EditorialSplit.astro';
+import QuoteOverlay from './QuoteOverlay.astro';
+
+type StoryBlock =
+  | {
+      type: 'editorial-split';
+      image: { src: string; alt: string };
+      blocks: { title?: string; body: string }[];
+    }
+  | {
+      type: 'quote-overlay';
+      image: { src: string; alt: string };
+      quote: string;
+      attribution: string;
+    };
+
+interface Props {
+  data: StoryBlock;
+}
+const { data } = Astro.props as Props;
+---
+{data.type === 'editorial-split' && (
+  <EditorialSplit image={data.image} blocks={data.blocks} />
+)}
+{data.type === 'quote-overlay' && (
+  <QuoteOverlay image={data.image} quote={data.quote} attribution={data.attribution} />
+)}

--- a/src/data/packages.ts
+++ b/src/data/packages.ts
@@ -1,9 +1,23 @@
+export type StoryBlock =
+  | {
+      type: "editorial-split";
+      image: { src: string; alt: string };
+      blocks: { title?: string; body: string }[];
+    }
+  | {
+      type: "quote-overlay";
+      image: { src: string; alt: string };
+      quote: string;
+      attribution: string;
+    };
+
 export type PackageEntry = {
   slug: string;
   title: string;
   summary: string;
   days: { day: string; items: string[] }[];
   images: { src: string; alt: string; story: string }[];
+  story?: StoryBlock;
   faqs: { q: string; a: string }[];
   reviews: { name: string; rating: number; text: string }[];
 };
@@ -32,6 +46,23 @@ export const packages: PackageEntry[] = [
         story: "Climb Daulatabad's steep ramps for sweeping Deccan views.",
       },
     ],
+    story: {
+      type: "editorial-split",
+      image: {
+        src: "/images/destinations/ellora.jpg",
+        alt: "Ellora temple",
+      },
+      blocks: [
+        {
+          title: "Ancient Artistry",
+          body: "Centuries-old Buddhist murals adorn the silent halls of Ajanta.",
+        },
+        {
+          title: "Engineering Marvel",
+          body: "The monolithic Kailasa temple shows the scale of ancient craftsmanship.",
+        },
+      ],
+    },
     days: [
       {
         day: "Day 1",

--- a/src/pages/packages/[slug].astro
+++ b/src/pages/packages/[slug].astro
@@ -3,6 +3,7 @@ import '../../styles/globals.css';
 import Header from '@/components/Header.astro';
 import Footer from '@/components/Footer.astro';
 import FAQ from '@/components/FAQ.astro';
+import StoryTemplateSwitcher from '@/components/story/StoryTemplateSwitcher.astro';
 import { packages } from '@/data/packages';
 import { destinations } from '@/data/destinations';
 import pricing from '@/data/pricing.json';
@@ -134,6 +135,14 @@ function formatINR(n: number) {
             </details>
           </div>
         </section>
+        {entry.story && (
+          <section class="mt-6">
+            <h3 class="text-lg font-bold mb-3">Story</h3>
+            <div class="card p-0">
+              <StoryTemplateSwitcher data={entry.story} />
+            </div>
+          </section>
+        )}
         {entry.faqs.length > 0 && (
           <section class="mt-6">
             <h3 class="text-lg font-bold mb-3">FAQ</h3>


### PR DESCRIPTION
## Summary
- add StoryTemplateSwitcher with EditorialSplit and QuoteOverlay layouts
- inject story section above FAQ on package detail page
- extend package data with optional story blocks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab2463470c8332b9ba2e8007ae4186