### PR TITLE
Add toggle to package story section

### DIFF
--- a/src/pages/packages/[slug].astro
+++ b/src/pages/packages/[slug].astro
@@ -137,10 +137,12 @@ function formatINR(n: number) {
         </section>
         {entry.story && (
           <section class="mt-6">
-            <h3 class="text-lg font-bold mb-3">Story</h3>
-            <div class="card p-0">
-              <StoryTemplateSwitcher data={entry.story} />
-            </div>
+            <details class="card p-0" open>
+              <summary class="cursor-pointer text-lg font-bold px-6 py-4">Story</summary>
+              <div class="px-6 pb-6">
+                <StoryTemplateSwitcher data={entry.story} />
+              </div>
+            </details>
           </section>
         )}
         {entry.faqs.length > 0 && (

--- a/src/pages/packages/__tests__/story-toggle.test.ts
+++ b/src/pages/packages/__tests__/story-toggle.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'astro/test';
+import Page from '../[slug].astro';
+import { packages } from '@/data/packages';
+
+describe('package story toggle', () => {
+  it('wraps story section in a details element', async () => {
+    const slug = packages.find(p => p.story)?.slug as string;
+    const { getByText } = await render(Page, { params: { slug } });
+    const summary = getByText('Story');
+    expect(summary.parentElement?.tagName).toBe('DETAILS');
+  });
+});
+


### PR DESCRIPTION
## Summary
- wrap story section in a `<details>` element so it's toggleable
- test that package detail pages render story inside a details element

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab32f750f8833299e9c35865c0225c