### PR TITLE
Add quote overlay toggle for stories

### DIFF
--- a/src/components/story/StoryQuoteToggle.astro
+++ b/src/components/story/StoryQuoteToggle.astro
@@ -1,0 +1,49 @@
+---
+import StoryTemplateSwitcher from './StoryTemplateSwitcher.astro';
+import QuoteOverlay from './QuoteOverlay.astro';
+
+interface QuoteData {
+  image: { src: string; alt: string };
+  quote: string;
+  attribution: string;
+}
+
+interface Props {
+  story: {
+    type: 'editorial-split';
+    image: { src: string; alt: string };
+    blocks: { title?: string; body: string }[];
+  };
+  quote: QuoteData;
+}
+
+const { story, quote } = Astro.props as Props;
+---
+<div>
+  <div class="flex gap-2 mb-4">
+    <button id="story-view-btn" class="px-3 py-1 text-sm border rounded" type="button">Story</button>
+    <button id="quote-view-btn" class="px-3 py-1 text-sm border rounded" type="button">Quote</button>
+  </div>
+  <div id="story-view">
+    <StoryTemplateSwitcher data={story} />
+  </div>
+  <div id="quote-view" class="hidden">
+    <QuoteOverlay image={quote.image} quote={quote.quote} attribution={quote.attribution} />
+  </div>
+</div>
+<script is:inline>
+  {`(() => {
+    const storyBtn = document.getElementById('story-view-btn');
+    const quoteBtn = document.getElementById('quote-view-btn');
+    const storyView = document.getElementById('story-view');
+    const quoteView = document.getElementById('quote-view');
+    storyBtn?.addEventListener('click', () => {
+      storyView?.classList.remove('hidden');
+      quoteView?.classList.add('hidden');
+    });
+    quoteBtn?.addEventListener('click', () => {
+      quoteView?.classList.remove('hidden');
+      storyView?.classList.add('hidden');
+    });
+  })();`}
+</script>

--- a/src/components/story/__tests__/StoryQuoteToggle.test.ts
+++ b/src/components/story/__tests__/StoryQuoteToggle.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'astro/test';
+import StoryQuoteToggle from '../StoryQuoteToggle.astro';
+
+describe('StoryQuoteToggle', () => {
+  it('renders both story and quote views', async () => {
+    const story = {
+      type: 'editorial-split' as const,
+      image: { src: '/img.jpg', alt: 'alt text' },
+      blocks: [{ body: 'split body' }]
+    };
+    const quote = {
+      image: { src: '/img2.jpg', alt: 'alt text' },
+      quote: 'a quote',
+      attribution: 'Someone'
+    };
+    const { getByText } = await render(StoryQuoteToggle, { props: { story, quote } });
+    expect(getByText('split body')).toBeDefined();
+    expect(getByText('a quote')).toBeDefined();
+  });
+});

--- a/src/pages/packages/[slug].astro
+++ b/src/pages/packages/[slug].astro
@@ -4,6 +4,7 @@ import Header from '@/components/Header.astro';
 import Footer from '@/components/Footer.astro';
 import FAQ from '@/components/FAQ.astro';
 import StoryTemplateSwitcher from '@/components/story/StoryTemplateSwitcher.astro';
+import StoryQuoteToggle from '@/components/story/StoryQuoteToggle.astro';
 import { packages } from '@/data/packages';
 import { destinations } from '@/data/destinations';
 import pricing from '@/data/pricing.json';
@@ -140,7 +141,18 @@ function formatINR(n: number) {
             <details class="card p-0" open>
               <summary class="cursor-pointer text-lg font-bold px-6 py-4">Story</summary>
               <div class="px-6 pb-6">
-                <StoryTemplateSwitcher data={entry.story} />
+                {entry.reviews.length > 0 ? (
+                  <StoryQuoteToggle
+                    story={entry.story}
+                    quote={{
+                      image: entry.images[0] ?? { src: '', alt: '' },
+                      quote: entry.reviews[0].text,
+                      attribution: entry.reviews[0].name
+                    }}
+                  />
+                ) : (
+                  <StoryTemplateSwitcher data={entry.story} />
+                )}
               </div>
             </details>
           </section>


### PR DESCRIPTION
## Summary
- add StoryQuoteToggle component with buttons to switch between story and quote views
- integrate quote toggle into package stories
- cover story/quote toggle with a render test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a869d0883328c25906f1450b3ed