### PR TITLE
Use dynamic base URL for sitemap and robots

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,16 +1,22 @@
 import type { APIRoute } from 'astro';
 
-export const GET: APIRoute = () => {
-// If you ever want to block staging, add a condition for *.netlify.app here.
-  const body = [
-'User-agent: *',
-'Allow: /',
-'',
-'Sitemap: https://axiscabs.com/sitemap.xml',
-''
-].join('\n');
+function baseUrl(site?: URL): string {
+  const env = process.env.SITE || process.env.URL || '';
+  return (env || site?.toString() || 'https://axiscabs.com').replace(/\/$/, '');
+}
 
-return new Response(body, {
-headers: { 'Content-Type': 'text/plain; charset=utf-8' }
-});
+export const GET: APIRoute = ({ site }) => {
+  const base = baseUrl(site);
+  const body = [
+    'User-agent: *',
+    'Allow: /',
+    '',
+    `Sitemap: ${base}/sitemap.xml`,
+    '',
+  ].join('\n');
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
 };
+

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,38 +1,31 @@
-//import type { APIRoute } from 'astro';
-//import { routes } from '@/data/routes';
-//import { packages } from '@/data/packages';
-//import { gems } from '@/data/gems';
-//
-//export const GET: APIRoute = ({ site }) => {
-//const base = (site ?? new URL('/', 'https://axiscabs.com')).toString().replace(/\/$/, '');
-//
-//  const paths = [
-//'',
-//...routes.map((r) => `city-to-city/${r.slug}`),
-//...packages.map((p) => `packages/${p.slug}`),
-//...gems.map((g) => `hidden-gems/${g.slug}`)
-//];
-//
-//const urls = paths.map((p) => `<url><loc>${base}/${p}</loc></url>`).join('');
-//const xml = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`;
-//
-//return new Response(xml, { headers: { 'Content-Type': 'application/xml' } });
-//};
-
-
 import type { APIRoute } from 'astro';
 import { routes } from '@/data/routes';
 import { packages } from '@/data/packages';
 import { gems } from '@/data/gems';
 
-export const GET: APIRoute = () => {
+function baseUrl(site?: URL): string {
+  const env = process.env.SITE || process.env.URL || '';
+  return (env || site?.toString() || 'https://axiscabs.com').replace(/\/$/, '');
+}
+
+export const GET: APIRoute = ({ site }) => {
+  const base = baseUrl(site);
   const pages = [
     '',
     ...routes.map((r) => `city-to-city/${r.slug}`),
     ...packages.map((p) => `packages/${p.slug}`),
     ...gems.map((g) => `hidden-gems/${g.slug}`),
   ];
-  const urls = pages.map((p) => `<url><loc>https://axiscabs.com/${p}</loc></url>`).join('');
-  const xml = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`;
-  return new Response(xml, { headers: { 'Content-Type': 'application/xml' } });
+
+  const urls = pages.map((p) => `<url><loc>${base}/${p}</loc></url>`).join('');
+  const xml =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' +
+    urls +
+    '</urlset>';
+
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/xml' },
+  });
 };
+


### PR DESCRIPTION
## Summary
- derive base URL from `Astro.site` or environment variables
- build sitemap and robots entries dynamically for staging and production

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c684a25c7483328c143cc4fcfec35e