### PR TITLE
Add API submission test coverage

### DIFF
--- a/src/pages/api/__tests__/leads-submit.test.ts
+++ b/src/pages/api/__tests__/leads-submit.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const createClient = vi.fn();
+vi.mock("@supabase/supabase-js", () => ({ createClient }));
+
+describe("POST /api/leads-submit", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    createClient.mockReset();
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+  });
+
+  it("accepts a valid lead", async () => {
+    const single = vi.fn().mockResolvedValue({ data: { id: 1 }, error: null });
+    createClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({ single })
+        })
+      })
+    });
+
+    const { POST } = await import("../leads-submit");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "John", whatsapp: "12345678" })
+    });
+    const res = await POST({ request: req } as any);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, id: 1 });
+  });
+
+  it("rejects invalid JSON", async () => {
+    createClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({ single: vi.fn() })
+        })
+      })
+    });
+
+    const { POST } = await import("../leads-submit");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{" // malformed
+    });
+    const res = await POST({ request: req } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("requires name and valid phone", async () => {
+    const { POST } = await import("../leads-submit");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "", whatsapp: "123" })
+    });
+    const res = await POST({ request: req } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when supabase fails", async () => {
+    const single = vi.fn().mockResolvedValue({ data: null, error: { message: "db" } });
+    createClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({ single })
+        })
+      })
+    });
+
+    const { POST } = await import("../leads-submit");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "John", whatsapp: "12345678" })
+    });
+    const res = await POST({ request: req } as any);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/pages/api/__tests__/reviews-submit.test.ts
+++ b/src/pages/api/__tests__/reviews-submit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const createClient = vi.fn();
+vi.mock("@supabase/supabase-js", () => ({ createClient }));
+
+describe("POST /api/reviews-submit", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    createClient.mockReset();
+    vi.stubEnv("SUPABASE_URL", "https://example.supabase.co");
+    vi.stubEnv("PUBLIC_SUPABASE_ANON_KEY", "anon-key");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("accepts a valid review", async () => {
+    const single = vi.fn().mockResolvedValue({ data: { id: 1 }, error: null });
+    createClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({ single })
+        })
+      })
+    });
+
+    const { POST } = await import("../reviews-submit");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        rating: 5,
+        comment: "Great service with punctual drivers.",
+        consent: true
+      })
+    });
+    const res = await POST({ request: req } as any);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, id: 1, status: "pending", flagged: false });
+  });
+
+  it("rejects invalid JSON", async () => {
+    createClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({ single: vi.fn() })
+        })
+      })
+    });
+
+    const { POST } = await import("../reviews-submit");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{" // malformed
+    });
+    const res = await POST({ request: req } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("enforces required fields", async () => {
+    const { POST } = await import("../reviews-submit");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rating: 5, comment: "Too short", consent: true })
+    });
+    const res = await POST({ request: req } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when supabase fails", async () => {
+    const single = vi.fn().mockResolvedValue({ data: null, error: { message: "fail" } });
+    createClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({ single })
+        })
+      })
+    });
+
+    const { POST } = await import("../reviews-submit");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        rating: 5,
+        comment: "Great service with punctual drivers.",
+        consent: true
+      })
+    });
+    const res = await POST({ request: req } as any);
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest suites for leads and reviews submission APIs
- stub Supabase interactions for success and failure cases
- validate JSON parsing, required fields, and response codes

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install --registry=https://registry.npmjs.org` *(fails: 403 Forbidden for @parcel/watcher-wasm)*

------
https://chatgpt.com/codex/tasks/task_e_68c684bd240883329b29bc35181f500c